### PR TITLE
Update MapCollection.cls - remove System.debug statement

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/MapCollection.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/MapCollection.cls
@@ -60,7 +60,9 @@ global with sharing class MapCollection {
     }
 
     private static void putType(SObject obj, String fieldName, String fieldType, String fieldValue) {
-        System.debug('fieldName, fieldType, fieldValue: '+fieldName+', '+fieldType+', '+fieldValue);
+
+        // System.debug('fieldName, fieldType, fieldValue: '+fieldName+', '+fieldType+', '+fieldValue);
+
         if (fieldType != 'Boolean' && (fieldValue == null || fieldValue == '')) {
             obj.put(fieldName, null);
         } else if (fieldType == 'Date') {


### PR DESCRIPTION
I'm using this Step for high volume record changes, and therefore this Debug statement gets called a significant number of times, filling the logs and possibly having a minor impact on performance.